### PR TITLE
ci/cd: Do not build zero-copy version

### DIFF
--- a/.github/workflows/pull_request_fc.yml
+++ b/.github/workflows/pull_request_fc.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build virtio-accel
         working-directory: virtio-accel
-        run: make KDIR=${GITHUB_WORKSPACE}/linux
+        run: make KDIR=${GITHUB_WORKSPACE}/linux ZC=0
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
At the moment, Firecracker does not support the zero-copy version of the
module. Have the Github action build the non-zero-copy version for using
in testing.

Signed-off-by: Babis Chalios <mail@bchalios.io>