### PR TITLE
ci: Add release orchestration and improve code style

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      # Workaround for https://github.com/dependabot/dependabot-core/issues/6345
+      - "/.github/actions/*"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci(deps)"

--- a/.github/workflows/main-build-and-upload.yml
+++ b/.github/workflows/main-build-and-upload.yml
@@ -9,6 +9,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: read-all
+
 jobs:
   build-dist:
     name: Build and Upload

--- a/.github/workflows/main-build-and-upload.yml
+++ b/.github/workflows/main-build-and-upload.yml
@@ -22,3 +22,13 @@ jobs:
       options: ''
       upload-subpath: 'virtio-accel'
     secrets: inherit
+
+  update-release:
+    needs: build-dist
+    name: Update Release
+    if: always()
+    uses: nubificus/vaccel/.github/workflows/update-release.yml@main
+    with:
+      artifacts-path: 'virtio-accel'
+      result: ${{ needs.build-dist.result }}
+    secrets: inherit

--- a/.github/workflows/pr-build-and-verify.yml
+++ b/.github/workflows/pr-build-and-verify.yml
@@ -8,8 +8,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions: read-all
 
 jobs:
   check-pr-status:
@@ -20,7 +23,7 @@ jobs:
 #  test-build:
 #    needs: check-pr-status
 #    name: Test Build
-#    if: ${{ needs.check-pr-status.outputs.expects-checks == 'true' }}
+#    if: needs.check-pr-status.outputs.expects-checks == 'true'
 #    uses: nubificus/vaccel/.github/workflows/test-build.yml@main
 #    with:
 #      options: ''
@@ -30,7 +33,7 @@ jobs:
   verify-build:
     needs: check-pr-status
     name: Verify Build
-    if: ${{ needs.check-pr-status.outputs.expects-checks == 'true' }}
+    if: needs.check-pr-status.outputs.expects-checks == 'true'
     uses: ./.github/workflows/verify-build.yml
     with:
       runner-archs: '["amd64", "arm64"]'
@@ -45,14 +48,14 @@ jobs:
   validate-files-and-commits:
     needs: check-pr-status
     name: Validate Files and Commits
-    if: ${{ needs.check-pr-status.outputs.expects-checks == 'true' }}
+    if: needs.check-pr-status.outputs.expects-checks == 'true'
     uses: nubificus/vaccel/.github/workflows/validate-files-and-commits.yml@main
     secrets: inherit
 
   validate-code:
     needs: check-pr-status
     name: Validate Code
-    if: ${{ needs.check-pr-status.outputs.expects-checks == 'true' }}
+    if: needs.check-pr-status.outputs.expects-checks == 'true'
     uses: nubificus/vaccel/.github/workflows/validate-code.yml@main
     with:
       skip-cppcheck: true
@@ -79,11 +82,11 @@ jobs:
       - validate-code
     name: Jobs Completed
     if: >-
-      ${{ always() &&
-        (needs.check-pr-status.outputs.is-approved == 'true' ||
-          (needs.check-pr-status.outputs.expects-checks == 'true' &&
-            !contains(needs.*.result, 'failure') &&
-            !contains(needs.*.result, 'cancelled'))) }}
+      always() &&
+      (needs.check-pr-status.outputs.is-approved == 'true' ||
+        (needs.check-pr-status.outputs.expects-checks == 'true' &&
+          !contains(needs.*.result, 'failure') &&
+          !contains(needs.*.result, 'cancelled')))
     runs-on: base-2204-amd64
     steps:
       - run: exit 0

--- a/.github/workflows/pr-trailers.yml
+++ b/.github/workflows/pr-trailers.yml
@@ -7,12 +7,15 @@ on:
     types: [synchronize, labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+permissions: read-all
 
 jobs:
 #  commit-coverage:
 #    name: Commit coverage report
-#    if: ${{ github.event.review.state == 'approved' }}
+#    if: github.event.review.state == 'approved'
 #    uses: ./.github/workflows/coverage-report.yml
 #    with:
 #      commit: true
@@ -21,7 +24,7 @@ jobs:
   check-pr-status:
 #    needs: commit-coverage
     name: Check PR status
-    if: ${{ always() && github.event.pull_request.base.ref == 'main' }}
+    if: always() && github.event.pull_request.base.ref == 'main'
     uses: nubificus/vaccel/.github/workflows/check-pr-status.yml@main
     with:
       pr-number: >-
@@ -33,7 +36,8 @@ jobs:
     needs: check-pr-status
     name: Add Git Trailers to PR commits
     if: >-
-      ${{ always() && github.event.pull_request.base.ref == 'main' &&
-        needs.check-pr-status.outputs.is-approved == 'true' }}
+      always() &&
+      github.event.pull_request.base.ref == 'main' &&
+      needs.check-pr-status.outputs.is-approved == 'true'
     uses: nubificus/vaccel/.github/workflows/add-git-trailers.yml@main
     secrets: inherit

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -6,7 +6,7 @@ on:
       actions-repo:
         type: string
         default: 'nubificus/vaccel'
-      actions-rev:
+      actions-ref:
         type: string
         default: 'main'
       runner:
@@ -50,10 +50,18 @@ on:
       AWS_SECRET_ACCESS_KEY:
         required: false
 
+permissions: read-all
+
+env:
+  DEFAULT_UPPATH: >-
+    ${{ inputs.package != 'vaccel' &&
+      format('{0}/{1}', 'plugins', inputs.package) || '' }}
+
 jobs:
   verify-build:
     name: Verify Build
-    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
+    runs-on: >-
+      ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
     strategy:
       matrix:
         arch: ["${{ fromJSON(inputs.runner-archs) }}"]
@@ -61,8 +69,9 @@ jobs:
       fail-fast: false
     env:
       ARCH: ${{ fromJson(inputs.runner-arch-map)[0][matrix.arch] }}
-      DEFAULT_UPPATH: ${{ (inputs.package != 'vaccel') && format('{0}/{1}', 'plugins', inputs.package) || '' }}
-      INSTALL_PREFIX: ${{github.workspace}}/artifacts/${{fromJson(inputs.runner-arch-map)[0][matrix.arch]}}/${{matrix.build-type}}
+      INSTALL_PREFIX: >-
+        ${{ format('{0}/artifacts/{1}/{2}', github.workspace,
+          fromJson(inputs.runner-arch-map)[0][matrix.arch], matrix.build-type) }}
     steps:
       - name: Parse repository names
         id: parse-repos
@@ -88,11 +97,11 @@ jobs:
           permission-contents: read
 
       - name: Checkout .github directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github
           repository: ${{ inputs.actions-repo }}
-          ref: ${{ inputs.actions-rev }}
+          ref: ${{ inputs.actions-ref }}
           token: ${{ steps.generate-token.outputs.token || github.token }}
 
       - name: Get revision info
@@ -109,12 +118,14 @@ jobs:
 
       - name: Set up Docker Buildx
         id: setup-buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Change to updated Docker Buildx
+        env:
+          BUILDX_NAME: ${{ steps.setup-buildx.outputs.name }}
         run: |
-          echo "Changing buildx to ${{ steps.setup-buildx.outputs.name }}"
-          docker buildx use "${{ steps.setup-buildx.outputs.name }}"
+          echo "Changing buildx to ${BUILDX_NAME}"
+          docker buildx use "$BUILDX_NAME"
 
       - name: Build project (dist)
         id: build-dist
@@ -133,18 +144,22 @@ jobs:
           docker buildx use default
 
       - name: Upload to s3
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-upload') || inputs.release == true }}
+        if: >-
+          contains(github.event.pull_request.labels.*.name, 'ok-to-upload') ||
+          inputs.release == true
         uses: ./.github/actions/upload-to-s3
         with:
           arch: ${{ env.ARCH }}
           build-type: ${{ matrix.build-type }}
           local-path: ${{ steps.build-dist.outputs.dist-path }}/*
-          remote-subpath: ${{ (inputs.upload-subpath != '' && inputs.upload-subpath) || env.DEFAULT_UPPATH }}
+          remote-subpath: >-
+            ${{ inputs.upload-subpath != '' &&
+              inputs.upload-subpath || env.DEFAULT_UPPATH }}
           access-key: ${{ secrets.AWS_ACCESS_KEY }}
           secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Clean-up
-        if: ${{ always() }}
+        if: always()
         run: |
           sudo rm -rf artifacts build*
           docker buildx use default

--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -43,7 +43,7 @@ on:
         type: boolean
         default: false
     secrets:
-      GIT_CLONE_PAT:
+      VACCEL_BOT_PRIVATE_KEY:
         required: false
       AWS_ACCESS_KEY:
         required: false
@@ -64,12 +64,36 @@ jobs:
       DEFAULT_UPPATH: ${{ (inputs.package != 'vaccel') && format('{0}/{1}', 'plugins', inputs.package) || '' }}
       INSTALL_PREFIX: ${{github.workspace}}/artifacts/${{fromJson(inputs.runner-arch-map)[0][matrix.arch]}}/${{matrix.build-type}}
     steps:
+      - name: Parse repository names
+        id: parse-repos
+        env:
+          ACTIONS_REPO: ${{ inputs.actions-repo }}
+        run: |
+          {
+            echo "repo-name=$(basename "$GITHUB_REPOSITORY")"
+            echo "actions-repo-name=$(basename "$ACTIONS_REPO")"
+          } >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Generate vaccel-bot token
+        id: generate-token
+        if: vars.VACCEL_BOT_CLIENT_ID
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.VACCEL_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.VACCEL_BOT_PRIVATE_KEY }}
+          repositories: |
+            ${{ steps.parse-repos.outputs.repo-name }}
+            ${{ steps.parse-repos.outputs.actions-repo-name }}
+          permission-contents: read
+
       - name: Checkout .github directory
         uses: actions/checkout@v4
         with:
           sparse-checkout: .github
           repository: ${{ inputs.actions-repo }}
           ref: ${{ inputs.actions-rev }}
+          token: ${{ steps.generate-token.outputs.token || github.token }}
 
       - name: Get revision info
         id: get-rev-info
@@ -80,8 +104,8 @@ jobs:
         with:
           fetch-depth: 0
           remote-actions-repo: ${{ inputs.actions-repo }}
-          token: ${{ secrets.GIT_CLONE_PAT || github.token }}
           ref: ${{ steps.get-rev-info.outputs.sha }}
+          token: ${{ steps.generate-token.outputs.token || github.token }}
 
       - name: Set up Docker Buildx
         id: setup-buildx

--- a/meson.build
+++ b/meson.build
@@ -2,8 +2,9 @@ project('virtio-accel', 'c',
   meson_version : '>=1.1',
   default_options : ['prefix=/'],
   version : run_command('sh', '-c',
-    'git submodule update --init >/dev/null && ' +
-    'scripts/common/generate-version.sh .',
+    '(git submodule update --init >/dev/null 2>&1 || true) && ' +
+    'scripts/common/generate-version.sh',
+    env: {'SH_SCRIPTS_DIR': meson.project_source_root() / 'scripts' / 'common'},
     check: true).stdout().strip())
 
 opt_kdir = get_option('kdir')
@@ -28,7 +29,7 @@ if opt_kdir != 'default'
 endif
 
 make_bin = find_program('make')
-make_sh = files(meson.project_source_root() + '/scripts/make.sh')
+make_sh = meson.project_source_root() / 'scripts' / 'make.sh'
 build_dir_src = meson.current_build_dir() / 'src'
 build_dir_virtio_accel = build_dir_src / 'virtio_accel.ko.p'
 
@@ -70,38 +71,49 @@ virtio_accel_dep = declare_dependency(
   sources: virtio_accel)
 
 if not meson.is_subproject()
+  env_vars_list = []
+  foreach key, value : env_vars + {'BUILD_DIR': build_dir_virtio_accel }
+    env_vars_list += key + '=' + value + ' '
+  endforeach
+
   meson.add_install_script(make_sh, make_bin,
     meson.current_source_dir(), build_dir_src, 'virtio_accel.ko',
     'modules_install',
-    'BUILD_DIR=' + build_dir_virtio_accel,
+    env_vars_list,
     skip_if_destdir : true)
-
-  meson.add_dist_script(
-    'scripts/dist.sh',
-    'virtio-accel',
-    get_option('buildtype'),
-    'DEBUG',
-    debug,
-    'PROFILING',
-    opt_profiling.to_int().to_string(),
-    )
 endif
+
+version_only = meson.is_subproject() ? '--version-only' : ''
+meson.add_dist_script(
+  'scripts/dist.sh',
+  '-n', meson.project_name(),
+  '-v', meson.project_version(),
+  '-t', get_option('buildtype'),
+  '-a', 'profiling=' + opt_profiling.to_string(),
+  '--pkg-config-path', ':'.join(get_option('pkg_config_path')),
+  version_only)
 
 # helper vars for parent projects
 version = meson.project_version()
 
+pkg_arch = run_command('sh', '-c',
+  '. scripts/common/sh-common.sh; sh_print_arch',
+  check: true).stdout().strip()
+pkg_base_name = meson.project_name() + '_' + version + '_' + pkg_arch
+
 gen_vm_artifacts = custom_target('gen-vm-artifacts',
   command : ['scripts/gen-vm-artifacts.sh',
-    meson.project_source_root(),
-    meson.project_build_root(),
-    'DEBUG=' + debug + ' PROFILING=' + opt_profiling.to_int().to_string(),
-    meson.project_name(),
-    meson.project_version()],
+    '-n', meson.project_name(),
+    '-v', meson.project_version(),
+    '-t', get_option('buildtype'),
+    '-a', 'profiling=' + opt_profiling.to_string(),
+    '-s', meson.project_source_root(),
+    '-d', meson.project_build_root()],
   output : [
-    meson.project_name() + '-' + meson.project_version() + '-bin.tar.xz',
-    meson.project_name() + '-' + meson.project_version() + '-fc-bin.tar.xz',
-    meson.project_name() + '-' + meson.project_version() + '-linux-image.tar.xz',
-    meson.project_name() + '-' + meson.project_version() + '-fc-linux-image.tar.xz'],
+    pkg_base_name + '.tar.xz',
+    pkg_base_name + '_fc.tar.xz',
+    pkg_base_name + '_linux-image.tar.xz',
+    pkg_base_name + '_fc-linux-image.tar.xz'],
   console : true,
   build_by_default : false,
   install : false)

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,43 +1,39 @@
 #!/bin/sh
 # SPDX-License-Identifier: Apache-2.0
 
-# generate .version file
-SCRIPTS_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)
-cd "${MESON_SOURCE_ROOT}" || exit 1
-PKG_VERSION="$(sh "${SCRIPTS_DIR}"/common/generate-version.sh "" --no-dirty)"
-echo "${PKG_VERSION}" >"${MESON_DIST_ROOT}/.version"
+set -e
 
-# parse script args
-PKG_NAME=$1
-shift $(($# > 0 ? 1 : 0))
-BUILD_TYPE=$1
-shift $(($# > 0 ? 1 : 0))
-REPO_URL=$(git remote get-url origin |
-	sed 's/git@github.com:\(.*\)\.git/https:\/\/github.com\/\1/g')
+SCRIPTS_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)"
+SH_SCRIPTS_DIR="${SCRIPTS_DIR}/common"
+# shellcheck source=scripts/common/dist-common.sh
+. "${SH_SCRIPTS_DIR}/dist-common.sh"
 
-build_args=""
-c=$((0))
-for v in "$@"; do
-	[ -z "$v" ] && continue
+main() {
+	parse_args "$@"
 
-	if [ $((c % 2)) -eq 0 ]; then
-		build_args="${build_args}$v="
-	else
-		build_args="${build_args}$v "
+	printf 'Package    : %s\n' "$DIST_PKG_NAME"
+	printf 'Version    : %s\n' "$DIST_PKG_VERSION"
+	printf 'Repo URL   : %s\n' "$DIST_REPO_URL"
+	printf 'Build type : %s\n' "$DIST_BUILD_TYPE"
+	printf 'Meson args : %s\n\n' "$DIST_BUILD_ARGS"
+
+	printf 'Generating version file\n'
+	generate_version_file
+
+	if [ "$DIST_VERSION_ONLY" -eq 1 ]; then
+		return
 	fi
-	c=$((c + 1))
-done
 
-printf "Package    : %s\n" "${PKG_NAME}"
-printf "Version    : %s\n" "${PKG_VERSION}"
-printf "Build type : %s\n" "${BUILD_TYPE}"
-printf "Repo URL   : %s\n" "${REPO_URL}"
-printf "Build args : %s\n\n" "${build_args}"
+	cd "$MESON_DIST_ROOT" || sh_error "Could not change to ${MESON_DIST_ROOT}"
 
-cd "${MESON_DIST_ROOT}" || exit 1
+	printf 'Generating binary distribution\n\n'
+	"$SCRIPTS_DIR"/gen-vm-artifacts.sh \
+		-n "$DIST_PKG_NAME" \
+		-v "$DIST_PKG_VERSION" \
+		-t "$DIST_BUILD_TYPE" \
+		--raw-build-args "$DIST_BUILD_ARGS" \
+		-s "$MESON_SOURCE_ROOT" \
+		-d "$(dirname "$MESON_DIST_ROOT")"
+}
 
-# generate binary dist
-printf "%s\n\n" 'Generating binary distribution'
-"${SCRIPTS_DIR}"/gen-vm-artifacts.sh \
-	"${MESON_SOURCE_ROOT}" "$(dirname "${MESON_DIST_ROOT}")" \
-	"${build_args}" "${PKG_NAME}" "${PKG_VERSION}"
+main "$@"

--- a/scripts/docker/vm-artifacts.dockerfile
+++ b/scripts/docker/vm-artifacts.dockerfile
@@ -9,12 +9,17 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install prerequisites
 WORKDIR /
-# hadolint ignore=DL3008
+ENV VENV=/.venv
+ENV PATH="$VENV/bin:$PATH"
+# hadolint ignore=DL3008,DL3013
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential gcc g++ ca-certificates wget git bison flex bc \
-        libelf-dev libssl-dev cpio pahole kmod && \
+        libelf-dev libssl-dev cpio pahole kmod \
+        ninja-build pkg-config python3-pip python3-venv && \
     apt-get clean && \
+    python3 -m venv $VENV && \
+    pip install --no-cache-dir meson && \
     rm -rf /var/cache/apt /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Get linux source
@@ -52,12 +57,14 @@ RUN make olddefconfig && \
 WORKDIR /install/linux
 ARG PKG_NAME=virtio-accel
 ARG PKG_VERSION=0.0.0
+ARG PKG_ARCH="$TARGETARCH"
 RUN version=$(cat /linux/include/config/kernel.release) && \
     cp /linux/.config "linux-${version}-${TARGETARCH}-fc.config" && \
     find /linux \( -name 'vmlinux' -o -name '*Image' \) -exec \
         sh -c 'cp "$1" "$(basename "$1")-$2-$3-fc"' \
             sh {} "${version}" "${TARGETARCH}" \; && \
-    tar -pcJf "/install/${PKG_NAME}-${PKG_VERSION}-fc-linux-image.tar.xz" ./*
+    tar -pcJf \
+        "/install/${PKG_NAME}_${PKG_VERSION}_${PKG_ARCH}_fc-linux-image.tar.xz" ./*
 
 # build and pack virtio-accel
 WORKDIR /virtio-accel
@@ -65,13 +72,16 @@ ARG VIRTIO_ACCEL_SRC=.
 ARG BUILD_ARGS
 RUN --mount=type=bind,rw,target=/virtio-accel,source="${VIRTIO_ACCEL_SRC}" \
     build_dir="$(pwd)/build_$(od -vN 4 -An -tx1 /dev/urandom | tr -d " \n" ; echo)" && \
-    eval make modules modules_install \
-        KDIR=/linux \
-        BUILD_DIR="${build_dir}" \
-        INSTALL_MOD_PATH=/install/modules \
-        "${BUILD_ARGS}" && \
+    eval meson setup \
+        --prefix /install/modules \
+        -Dkdir=/linux \
+        "${BUILD_ARGS}" \
+        "${build_dir}" && \
+    meson compile -C "${build_dir}" && \
+    meson install -C "${build_dir}" && \
     tar --acls --xattrs --numeric-owner \
-        -JpScf "/install/${PKG_NAME}-${PKG_VERSION}-fc-bin.tar.xz" \
+        -JpScf \
+        "/install/${PKG_NAME}_${PKG_VERSION}_${PKG_ARCH}_fc.tar.xz" \
         -C /install/modules .
 
 # Generate generic artifacts
@@ -94,12 +104,14 @@ RUN cat generic.config >> .config && \
 WORKDIR /install/linux
 ARG PKG_NAME=virtio-accel
 ARG PKG_VERSION=0.0.0
+ARG PKG_ARCH="$TARGETARCH"
 RUN version=$(cat /linux/include/config/kernel.release) && \
     cp /linux/.config "linux-${version}-${TARGETARCH}.config" && \
     find /linux -name '*Image' -exec \
         sh -c 'cp "$1" "$(basename "$1")-$2-$3"' \
             sh {} "${version}" "${TARGETARCH}" \; && \
-    tar -pcJf "/install/${PKG_NAME}-${PKG_VERSION}-linux-image.tar.xz" ./*
+    tar -pcJf \
+        "/install/${PKG_NAME}_${PKG_VERSION}_${PKG_ARCH}_linux-image.tar.xz" ./*
 
 # build and pack virtio-accel
 WORKDIR /virtio-accel
@@ -107,13 +119,15 @@ ARG VIRTIO_ACCEL_SRC=.
 ARG BUILD_ARGS
 RUN --mount=type=bind,rw,target=/virtio-accel,source="${VIRTIO_ACCEL_SRC}" \
     build_dir="$(pwd)/build_$(od -vN 4 -An -tx1 /dev/urandom | tr -d " \n" ; echo)" && \
-    eval make modules modules_install \
-        KDIR=/linux \
-        BUILD_DIR="${build_dir}" \
-        INSTALL_MOD_PATH=/install/modules \
-        "${BUILD_ARGS}" && \
+    eval meson setup \
+        --prefix /install/modules \
+        -Dkdir=/linux \
+        "${BUILD_ARGS}" \
+        "${build_dir}" && \
+    meson compile -C "${build_dir}" && \
+    meson install -C "${build_dir}" && \
     tar --acls --xattrs --numeric-owner \
-        -JpScf "/install/${PKG_NAME}-${PKG_VERSION}-bin.tar.xz" \
+        -JpScf "/install/${PKG_NAME}_${PKG_VERSION}_${PKG_ARCH}.tar.xz" \
         -C /install/modules .
 
 # Copy artifacts to host

--- a/scripts/gen-vm-artifacts.sh
+++ b/scripts/gen-vm-artifacts.sh
@@ -3,55 +3,169 @@
 
 set -e
 
-SCRIPTS_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)
-DOCKER_DIR=${SCRIPTS_DIR}/docker
-SRC_DIR=${1:-"${MESON_SOURCE_ROOT:-"${SCRIPTS_DIR}/.."}"}
-shift $(($# > 0 ? 1 : 0))
-ARTIFACTS_DIR=${1:-"${MESON_BUILD_ROOT:-./vm-artifacts}"}
-shift $(($# > 0 ? 1 : 0))
-BUILD_ARGS=${1:-""}
-shift $(($# > 0 ? 1 : 0))
-PKG_NAME=${1:-virtio-accel}
-shift $(($# > 0 ? 1 : 0))
-PKG_VERSION=${1:-"$(sh "${SCRIPTS_DIR}/common/generate-version.sh" "")"}
-shift $(($# > 0 ? 1 : 0))
-RUN_DIR=/run/user/$(id -u)/${PKG_NAME}
+SCRIPTS_DIR="$(cd -- "$(dirname -- "$0")" >/dev/null && pwd -P)"
+SH_SCRIPTS_DIR="${SCRIPTS_DIR}/common"
+# shellcheck source=scripts/common/sh-common.sh
+. "${SH_SCRIPTS_DIR}/sh-common.sh"
 
-printf "Package                       : %s\n" "${PKG_NAME}"
-printf "Version                       : %s\n" "${PKG_VERSION}"
-printf "Build args                    : %s\n" "${BUILD_ARGS}"
-printf "Source directory              : %s\n" "${SRC_DIR}"
-printf "Docker files directory        : %s\n" "${DOCKER_DIR}"
-printf "Generated artifacts directory : %s\n\n" "${ARTIFACTS_DIR}"
+DOCKER_DIR="${SCRIPTS_DIR}/docker"
+PKG_ARCH="$(sh_print_arch)"
 
-mkdir -p "${ARTIFACTS_DIR}" "${RUN_DIR}"
+SRC_DIR_DEFAULT="${MESON_SOURCE_ROOT:-"${SCRIPTS_DIR}/.."}"
+ARTIFACTS_DIR_DEFAULT="${MESON_BUILD_ROOT:-'./vm-artifacts'}"
 
-cd "${SRC_DIR}"
+parse_args() {
+	short_opts='n:v:t:a:s:d:'
+	long_opts='pkg-name:,pkg-version:,build-type:,build-arg:,raw-build-args:'
+	long_opts="${long_opts},src-dir:,artifacts-dir:"
 
-printf "%s\n" 'Building virtio-accel artifacts'
-# Build artifacts
-res=0
-docker build --network=host -f "${DOCKER_DIR}/vm-artifacts.dockerfile" \
-	--build-arg "BUILD_ARGS=${BUILD_ARGS}" \
-	--build-arg "PKG_NAME=${PKG_NAME}" \
-	--build-arg "PKG_VERSION=${PKG_VERSION}" \
-	--target artifacts \
-	--output type=local,dest="${RUN_DIR}" "$@" . || res=$?
+	if ! getopt=$(getopt -o "$short_opts" --long "$long_opts" \
+		-n "$SH_SCRIPT_NAME" -- "$@"); then
+		sh_error 'Failed to parse args'
+	fi
 
-# Finalize and move files to artifacts dir
-if [ "${res}" = 0 ]; then
-	printf "\n"
-	files=$(find "${RUN_DIR}" -name "${PKG_NAME}-${PKG_VERSION}*.tar.xz")
-	uid=$(stat -c %u "${ARTIFACTS_DIR}")
-	gid=$(stat -c %g "${ARTIFACTS_DIR}")
-	for f in ${files}; do
-		chown "${uid}":"${gid}" "${f}"
-		mv "${f}" "${ARTIFACTS_DIR}/"
-		printf "%s\n" "Created ${ARTIFACTS_DIR}/$(basename "${f}")"
+	eval set -- "$getopt"
+
+	build_args=
+	while true; do
+		case "$1" in
+		'-n' | '--pkg-name')
+			# Package name
+			[ -z "$2" ] &&
+				sh_error "'$1' requires a non-empty string"
+			pkg_name="$2"
+			shift 2
+			;;
+		'-v' | '--pkg-version')
+			# Package version
+			[ -z "$2" ] &&
+				sh_error "'$1' requires a non-empty string"
+			pkg_version="$2"
+			shift 2
+			;;
+		'-t' | '--build-type')
+			# Build type
+			[ -z "$2" ] &&
+				sh_error "'$1' requires a non-empty string"
+			build_type="$2"
+			shift 2
+			;;
+		'-a' | '--build-arg')
+			# Build args
+			arg=$(echo "$2" | cut -d'=' -f1)
+			value=$(echo "$2" | cut -d'=' -f2-)
+			[ -z "${arg}" ] || [ -z "${value}" ] &&
+				sh_error "'$1' requires a string of the form 'arg=value'"
+			build_args="${build_args} -D${arg}=${value}"
+			unset arg
+			unset value
+			shift 2
+			;;
+		'-s' | '--src-dir')
+			# Source directory
+			[ -z "$2" ] &&
+				sh_error "'$1' requires a non-empty string"
+			src_dir="$2"
+			shift 2
+			;;
+		'-d' | '--artifacts-dir')
+			# Artifacts directory
+			[ -z "$2" ] &&
+				sh_error "'$1' requires a non-empty string"
+			artifacts_dir="$2"
+			shift 2
+			;;
+		'--raw-build-args')
+			# Raw build args (as passed to meson)
+			[ -z "$2" ] &&
+				sh_error "'$1' requires a non-empty string"
+			build_args="${build_args} ${2}"
+			shift 2
+			;;
+		--)
+			shift
+			break
+			;;
+		*)
+			sh_error 'Internal error parsing args'
+			;;
+		esac
 	done
-fi
 
-# Cleanup
-rm -rf "${RUN_DIR}"
+	if [ -z "$pkg_name" ] || [ -z "$pkg_version" ] ||
+		[ -z "$build_type" ]; then
+		sh_error 'Package name, version or buildtype was not provided'
+	fi
 
-exit "${res}"
+	src_dir="${src_dir:-"$SRC_DIR_DEFAULT"}"
+	artifacts_dir="${artifacts_dir:-"$ARTIFACTS_DIR_DEFAULT"}"
+
+	buildtype_arg="--buildtype=${build_type}"
+	if [ "${build_args#*"$buildtype_arg"*}" = "$build_args" ]; then
+		build_args="${build_args} ${buildtype_arg}"
+	fi
+
+	run_dir="/run/user/$(id -u)/${pkg_name}"
+
+	unset short_opts
+	unset long_opts
+	unset buildtype_arg
+}
+
+generate_artifacts() {
+	cd "$src_dir"
+
+	# Build artifacts
+	res=0
+	docker build --network=host \
+		-f "${DOCKER_DIR}/vm-artifacts.dockerfile" \
+		--build-arg "BUILD_ARGS=${build_args}" \
+		--build-arg "PKG_NAME=${pkg_name}" \
+		--build-arg "PKG_VERSION=${pkg_version}" \
+		--build-arg "PKG_ARCH=${PKG_ARCH}" \
+		--target artifacts \
+		--output type=local,dest="$run_dir" \
+		. || res=$?
+
+	# Finalize and move files to artifacts dir
+	if [ "$res" != 0 ]; then
+		cd - >/dev/null
+		sh_log_error 'Failed to build artifacts' "$res"
+		return
+	fi
+
+	printf "\n"
+	base_name="${pkg_name}_${pkg_version}"
+	files="$(find "$run_dir" -name "${base_name}*.tar.xz")"
+	uid="$(stat -c %u "$artifacts_dir")"
+	gid="$(stat -c %g "$artifacts_dir")"
+	for f in ${files}; do
+		chown "$uid":"$gid" "$f"
+		mv "$f" "${artifacts_dir}/"
+		printf 'Created %s\n' \
+			"${artifacts_dir}/$(basename "$f")"
+	done
+}
+
+main() {
+	parse_args "$@"
+
+	printf 'Package                       : %s\n' "$pkg_name"
+	printf 'Version                       : %s\n' "$pkg_version"
+	printf 'Architecture                  : %s\n' "$PKG_ARCH"
+	printf 'Build type                    : %s\n' "$build_type"
+	printf 'Meson args                    : %s\n' "$build_args"
+	printf 'Source directory              : %s\n' "$src_dir"
+	printf 'Docker files directory        : %s\n' "$DOCKER_DIR"
+	printf 'Generated artifacts directory : %s\n\n' "$artifacts_dir"
+
+	mkdir -p "$artifacts_dir" "$run_dir"
+
+	printf 'Building %s artifacts\n' "$pkg_name"
+	generate_artifacts
+
+	rm -rf "$run_dir"
+	exit "$res"
+}
+
+main "$@"

--- a/scripts/make.sh
+++ b/scripts/make.sh
@@ -10,7 +10,7 @@ OUTPUT=$4
 shift 4
 
 for a in "$@"; do
-	[ "$a" = "modules_install" ] && INSTALL=1 && break
+	[ "$a" = "modules_install" ] && install=1 && break
 done
 
 [ "${OUTPUT_DIR}" = "${SRC_DIR}" ] && return
@@ -21,6 +21,6 @@ fi
 
 "${MAKE_BIN}" -C "${SRC_DIR}" "$@"
 
-if [ -z "$INSTALL" ]; then
+if [ -z "$install" ]; then
 	cp "${BUILD_DIR}"/"${OUTPUT}" "${OUTPUT_DIR}"/"${OUTPUT}"
 fi


### PR DESCRIPTION
Add release orchestration and improve CI code style:
- Integrate automatic release orchestration introduced in https://github.com/nubificus/vaccel/pull/210
- Replace PAT with `vaccel-bot` tokens, scoped per step
- Group Dependabot updates, including custom actions
- Tidy up workflow code style and bump dependencies
- Update meson/scripts for the new dist/component versioning scheme